### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,6 +3,7 @@
 Most of the requirements of this projects are exactly the same as [maskrcnn-benchmark](https://github.com/facebookresearch/maskrcnn-benchmark). If you have any problem of your environment, you should check their [issues page](https://github.com/facebookresearch/maskrcnn-benchmark/issues) first. Hope you will find the answer.
 
 ### Requirements:
+- Python <= 3.8
 - PyTorch >= 1.2 (Mine 1.4.0 (CUDA 10.1))
 - torchvision >= 0.4 (Mine 0.5.0 (CUDA 10.1))
 - cocoapi


### PR DESCRIPTION
Python=3.9.7 does not work. Python=3.8 does. Got this error with Python 3.9.7:

```
nsatisfiableError: The following specifications were found
to be incompatible with the existing python installation in your environment:

Specifications:

  - pytorch=1.4.0 -> python[version='>=2.7,<2.8.0a0|>=3.6,<3.7.0a0|>=3.7,<3.8.0a0|>=3.8,<3.9.0a0|>=3.5,<3.6.0a0']
  - torchvision=0.5.0 -> python[version='>=2.7,<2.8.0a0|>=3.5,<3.6.0a0|>=3.6,<3.7.0a0|>=3.8,<3.9.0a0|>=3.7,<3.8.0a0']

Your python: python=3.9

If python is on the left-most side of the chain, that's the version you've asked for.
When python appears to the right, that indicates that the thing on the left is somehow
not available for the python version you are constrained to. Note that conda will not
change your python version to a different minor version unless you explicitly specify
that.
```